### PR TITLE
Activate flake8 and fix warnings

### DIFF
--- a/dns-policy-operator/charmcraft.yaml
+++ b/dns-policy-operator/charmcraft.yaml
@@ -42,11 +42,6 @@ provides:
     interface: dns_record
 
 parts:
-  app:
-    plugin: dump
-    source: .
-    prime:
-      - dns-policy-app_*_amd64.snap
   charm:
     build-snaps:
       - rustup

--- a/dns-policy-operator/src/charm.py
+++ b/dns-policy-operator/src/charm.py
@@ -142,7 +142,7 @@ class DnsPolicyCharm(ops.CharmBase):
     def _on_install(self, _: ops.InstallEvent) -> None:
         """Handle install event."""
         self.unit.status = ops.MaintenanceStatus("Preparing dns-policy-app")
-        self.dns_policy.setup(self.unit.name)
+        self.dns_policy.setup()
         self._timer.start(
             self.unit.name,
             "reconcile",

--- a/dns-policy-operator/src/charm.py
+++ b/dns-policy-operator/src/charm.py
@@ -73,6 +73,11 @@ class DnsPolicyCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus()
 
     def _on_reconcile(self, _: ReconcileEvent) -> None:
+        """Reconcile incoming requests with the workload.
+
+        Raises:
+            TooManyRelatedAppsError: Raised when related to multiple providers
+        """
         if not self.model.unit.is_leader():
             return
         relation_data = self.dns_record_provider.get_remote_relation_data()
@@ -114,6 +119,7 @@ class DnsPolicyCharm(ops.CharmBase):
 
         Args:
             relation_data: input relation data
+
         Returns:
             A list of DnsEntry
         """
@@ -150,22 +156,15 @@ class DnsPolicyCharm(ops.CharmBase):
         )
 
     def _on_database_created(self, _: DatabaseCreatedEvent) -> None:
-        """Handle database created.
-
-        Args:
-            event: Event triggering the database created handler.
-        """
+        """Handle database created."""
         self._handle_database_endpoint_changes()
 
     def _on_database_endpoints_changed(self, _: DatabaseEndpointsChangedEvent) -> None:
-        """Handle endpoints change.
-
-        Args:
-            event: Event triggering the endpoints changed handler.
-        """
+        """Handle endpoints change."""
         self._handle_database_endpoint_changes()
 
     def _handle_database_endpoint_changes(self) -> None:
+        """Handle a database endpoint change."""
         self.unit.status = ops.MaintenanceStatus("Preparing database")
         self.dns_policy.configure(
             dns_policy.DnsPolicyConfig.from_charm(self, self._database.get_relation_data())

--- a/dns-policy-operator/src/constants.py
+++ b/dns-policy-operator/src/constants.py
@@ -3,7 +3,7 @@
 
 """File containing constants to be used in the charm."""
 
-DNS_SNAP_NAME = "dns-policy-app"
+DNS_SNAP_NAME = "charmed-dns-policy"
 DNS_SNAP_SERVICES = ["nginx", "gunicorn"]
 SNAP_PACKAGES = {
     DNS_SNAP_NAME: {"channel": "edge"},

--- a/dns-policy-operator/src/models.py
+++ b/dns-policy-operator/src/models.py
@@ -19,6 +19,7 @@ class DnsEntry(pydantic.BaseModel):
         record_class: example: "IN"
         record_type: example: "A"
         record_data: example: "42.42.42.42"
+        status: example: "pending"
     """
 
     domain: str = pydantic.Field(min_length=1)

--- a/dns-policy-operator/tests/conftest.py
+++ b/dns-policy-operator/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
-    parser.addoption("--dns-policy-charm-file", action="store", default=None)
+    parser.addoption("--charm-file", action="store", default=None)
     parser.addoption("--bind-charm-file", action="store", default=None)
     parser.addoption(
         "--use-existing",

--- a/dns-policy-operator/tests/integration/conftest.py
+++ b/dns-policy-operator/tests/integration/conftest.py
@@ -58,7 +58,7 @@ async def dns_policy_fixture(
 
     resources: dict = {}
 
-    if charm := pytestconfig.getoption("--dns-policy-charm-file"):
+    if charm := pytestconfig.getoption("--charm-file"):
         application = await model.deploy(
             f"./{charm}",
             application_name=dns_policy_name,

--- a/dns-policy-operator/tox.ini
+++ b/dns-policy-operator/tox.ini
@@ -65,7 +65,7 @@ commands =
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
-    # pflake8 {[vars]all_path}
+    pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
     mypy {[vars]all_path}


### PR DESCRIPTION
### Overview

flake8 was commented out (I'm not sure why the tests passed without it). But it's fixed now.  
I also changed the dns-policy operator to install its workload from charmhub.

This is necessary for https://github.com/canonical/dns-operators/pull/108 to pass


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
