### PR TITLE
Use hostmaster instead of mail for the SOA email

### DIFF
--- a/bind-operator/src/templates.py
+++ b/bind-operator/src/templates.py
@@ -10,14 +10,14 @@ import constants
 
 ZONE_SERVICE = f"""$ORIGIN {constants.ZONE_SERVICE_NAME}.
 $TTL 600
-@ IN SOA {constants.ZONE_SERVICE_NAME}. mail.{constants.ZONE_SERVICE_NAME}. ( {{serial}} 1d 1h 1h 10m )
+@ IN SOA {constants.ZONE_SERVICE_NAME}. hostmaster.{constants.ZONE_SERVICE_NAME}. ( {{serial}} 1d 1h 1h 10m )
 @ IN NS localhost.
 status IN TXT "ok"
 """
 
 ZONE_APEX_TEMPLATE = """$ORIGIN {zone}.
 $TTL 600
-@ IN SOA {zone}. mail.{zone}. ( {serial} 1d 1h 1h 10m )
+@ IN SOA {zone}. hostmaster.{zone}. ( {serial} 1d 1h 1h 10m )
 """
 
 ZONE_APEX_NS_TEMPLATE = "@ IN NS ns{number}.\nns{number} IN A {ip}\n"


### PR DESCRIPTION
Applicable spec: <link>

### Overview

`hostmaster` is encouraged to be used as per this [RFC](https://www.ietf.org/rfc/rfc2142.txt).  
We will give a config option to change that in the future.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
