### PR TITLE
Run ci on push to main

### DIFF
--- a/.github/workflows/integration-test-bind-operator.yaml
+++ b/.github/workflows/integration-test-bind-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'bind-operator/**'
       - '.github/workflows/integration-test-bind-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration-test-dns-integrator-operator.yaml
+++ b/.github/workflows/integration-test-dns-integrator-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'dns-integrator-operator/**'
       - '.github/workflows/integration-test-dns-integrator-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   integration-tests:

--- a/.github/workflows/integration-test-dns-policy-operator.yaml
+++ b/.github/workflows/integration-test-dns-policy-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'dns-policy-operator/**'
       - '.github/workflows/integration-test-dns-policy-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   integration-tests:

--- a/.github/workflows/test-charmed-bind.yaml
+++ b/.github/workflows/test-charmed-bind.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'charmed-bind/**'
       - '.github/workflows/test-charmed-bind.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   shellcheck:

--- a/.github/workflows/test-charmed-dns-policy.yaml
+++ b/.github/workflows/test-charmed-dns-policy.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'charmed-dns-policy/**'
       - '.github/workflows/test-charmed-dns-policy.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   django-tests:

--- a/.github/workflows/unit-test-bind-operator.yaml
+++ b/.github/workflows/unit-test-bind-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'bind-operator/**'
       - '.github/workflows/unit-test-bind-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-test-dns-integrator-operator.yaml
+++ b/.github/workflows/unit-test-dns-integrator-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'dns-integrator-operator/**'
       - '.github/workflows/unit-test-dns-integrator-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-test-dns-policy-operator.yaml
+++ b/.github/workflows/unit-test-dns-policy-operator.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'dns-policy-operator/**'
       - '.github/workflows/unit-test-dns-policy-operator.yaml'
+  push:
+    branches:
+      - main
 
 jobs:
   unit-tests:


### PR DESCRIPTION
### Overview

Charms don't get published on `main` because the CI is not automatically run for them and they need artifacts to be produced

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
