### PR TITLE
Fix issues found in local audit for style guide checks

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,3 @@
+misconfiguring
+requirers
+systemd

--- a/.github/workflows/unit-test-bind-operator.yaml
+++ b/.github/workflows/unit-test-bind-operator.yaml
@@ -17,3 +17,4 @@ jobs:
       self-hosted-runner: false
       self-hosted-runner-label: "edge"
       working-directory: ./bind-operator
+      vale-style-check: true

--- a/.github/workflows/unit-test-dns-integrator-operator.yaml
+++ b/.github/workflows/unit-test-dns-integrator-operator.yaml
@@ -17,3 +17,4 @@ jobs:
       self-hosted-runner: false
       self-hosted-runner-label: "edge"
       working-directory: ./dns-integrator-operator
+      vale-style-check: true

--- a/.github/workflows/unit-test-dns-policy-operator.yaml
+++ b/.github/workflows/unit-test-dns-policy-operator.yaml
@@ -17,3 +17,4 @@ jobs:
       self-hosted-runner: false
       self-hosted-runner-label: "edge"
       working-directory: ./dns-policy-operator
+      vale-style-check: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,18 +14,12 @@ source venv/bin/activate
 This project uses `tox` for managing test environments. There are some pre-configured environments
 that can be used for linting and formatting code when you're preparing contributions to the charm:
 
-```shell
-# update your code according to linting rules
-tox run -e format
-# code style
-tox run -e lint
-# unit tests
-tox run -e unit
-# integration tests
-tox run -e integration
-# runs 'format', 'lint', and 'unit' environments
-tox
-```
+* `tox`: Runs all of the basic checks (`lint`, `unit`, `static`, and `coverage-report`).
+* `tox -e fmt`: Runs formatting using `black` and `isort`.
+* `tox -e lint`: Runs a range of static code analysis to check the code.
+* `tox -e static`: Runs other checks such as `bandit` for security issues.
+* `tox -e unit`: Runs the unit tests.
+* `tox -e integration`: Runs the integration tests.
 
 ## Build the charm
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,16 @@ This project uses `tox` for managing test environments. There are some pre-confi
 that can be used for linting and formatting code when you're preparing contributions to the charm:
 
 ```shell
-tox run -e format        # update your code according to linting rules
-tox run -e lint          # code style
-tox run -e unit          # unit tests
-tox run -e integration   # integration tests
-tox                      # runs 'format', 'lint', and 'unit' environments
+# update your code according to linting rules
+tox run -e format
+# code style
+tox run -e lint
+# unit tests
+tox run -e unit
+# integration tests
+tox run -e integration
+# runs 'format', 'lint', and 'unit' environments
+tox
 ```
 
 ## Build the charm
@@ -29,5 +34,3 @@ Build the charm in this git repository using:
 ```shell
 charmcraft pack
 ```
-
-<!-- You may want to include any contribution/style guidelines in this document>

--- a/bind-operator/README.md
+++ b/bind-operator/README.md
@@ -31,7 +31,7 @@ start serving those DNS records.
 ### Basic operations
 
 No actions are available as this charm is meant to be operated through its integrations.  
-The charm can integrate with any requirer charm implementing the [dns_record interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
+The charm can integrate with any requirer charm implementing the [`dns_record` interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
 
 ## Learn more
 * [Read more](https://charmhub.io/bind/docs)

--- a/bind-operator/tests/integration/any_charm.py
+++ b/bind-operator/tests/integration/any_charm.py
@@ -33,7 +33,7 @@ class AnyCharm(AnyCharmBase):
         """
         super().__init__(*args, **kwargs)
         self.on.define_event("reload_data", ReloadDataEvent)
-        self.dns_record = DNSRecordRequires(self)
+        self.dns_record = DNSRecordRequires(self, "require-dns-record")
         self.framework.observe(self.on.reload_data, self._on_reload_data)
 
     def _on_reload_data(self, _: ReloadDataEvent) -> None:

--- a/bind-operator/tests/integration/helpers.py
+++ b/bind-operator/tests/integration/helpers.py
@@ -182,7 +182,9 @@ async def generate_anycharm_relation(
         args["to"] = machine
     any_charm = await ops_test.model.deploy("any-charm", storage=None, **args)
     await ops_test.model.wait_for_idle(apps=[any_charm.name])
-    await ops_test.model.add_relation(f"{any_charm.name}", f"{app.name}")
+    await ops_test.model.add_relation(
+        f"{any_charm.name}:require-dns-record", f"{app.name}:dns-record"
+    )
     await change_anycharm_relation(ops_test, any_charm.units[0], dns_entries)
 
 

--- a/charmed-bind/README.md
+++ b/charmed-bind/README.md
@@ -4,6 +4,8 @@ This snap is meant to be the workload of the [bind-operator](https://github.com/
 
 ## Get started
 
+The following instructions will show you how to deploy the snap.
+
 ### Install the snap
 The snap can be installed directly from the snap store.  
 [![Get it from the snap store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/charmed-bind)

--- a/charmed-dns-policy/README.md
+++ b/charmed-dns-policy/README.md
@@ -4,6 +4,8 @@ This snap is meant to be the workload of the [dns-policy-operator](https://githu
 
 ## Get started
 
+The following instructions will show you how to deploy the snap.
+
 ### Install the snap
 The snap can be installed directly from the snap store.  
 [![Get it from the snap store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/charmed-dns-policy)

--- a/dns-integrator-operator/README.md
+++ b/dns-integrator-operator/README.md
@@ -24,7 +24,7 @@ Use the configuration of the charm to decide which resource record requests you 
 ### Basic operations
 
 No actions are available as this charm is meant to be operated through its integrations.  
-The charm can integrate with any requirer charm implementing the [dns_record interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
+The charm can integrate with any requirer charm implementing the [`dns_record` interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
 
 ## Learn more
 * [Read more](https://charmhub.io/dns-integrator/docs)

--- a/dns-policy-operator/README.md
+++ b/dns-policy-operator/README.md
@@ -23,10 +23,12 @@ You then need to integrate it with a charm supporting the `dns_record` interface
 
 Before being able to review incoming DNS record requests, you will need to create a reviewer account.  
 To do that, use the `create-reviewer` command and then log in using its credentials to the dns-policy interface.  
-The charm can integrate with any requirer charm implementing the [dns_record interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
+The charm can integrate with any requirer charm implementing the [`dns_record` interface](https://canonical.github.io/charm-relation-interfaces/interfaces/dns_record/v0/).
 This charm will be give your reviewers the ability to manage all the DNS record requests from those requirer. Only one provider can be integrated.
 
 ### Basic operations
+
+These operations can be done once the charm is deployed.
 
 #### Create a reviewer
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -10,18 +10,18 @@ A good understanding of [the DNS system](https://bind9.readthedocs.io/en/stable/
 
 The DNS charms have security-related configurations, and misconfiguring them can lead to vulnerabilities.  
 
-### bind-operator
+### `bind-operator`
 
 No security-related configurations available.
 
-### dns-policy
+### `dns-policy`
 
 `dns-policy` uses a Django application under the hood for its API and web interface. As such, it can be configured following
 some of Django's configurations.  
 - **debug**: Puts the application in [debug mode](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-DEBUG).
 - **allowed-hosts**: Configures the [hosts allowed](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-ALLOWED_HOSTS) to reach the API and web interface of the application.
 
-### dns-integrator
+### `dns-integrator`
 
 No security-related configurations available.
 


### PR DESCRIPTION
### Overview

Use vale to lint documentation files. (Also fixes integration tests)

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
