### PR TITLE
Add reconcile loop to bind, add helpers in bind lib

### DIFF
--- a/bind-operator/src/charm.py
+++ b/bind-operator/src/charm.py
@@ -72,53 +72,18 @@ class BindCharm(ops.CharmBase):
         Reloading is used to take new configuration into account.
 
         """
-        relation_data = self._get_remote_relation_data()
-        if relation_data is None:
-            return
-        topology = self._topology()
-
-        # Load the last valid state
-        try:
-            last_valid_state = dns_data.load_state(
-                pathlib.Path(constants.DNS_CONFIG_DIR, "state.json").read_text(encoding="utf-8")
-            )
-        except FileNotFoundError:
-            # If we can't load the previous state,
-            # we assume that we need to regenerate the configuration
-            return
-        if dns_data.has_changed(relation_data, topology, last_valid_state):
-            self.bind.update_zonefiles_and_reload(relation_data, topology)
+        self._reconcile()
 
     def _on_peer_relation_joined(self, _: ops.RelationJoinedEvent) -> None:
         """Handle peer relation joined event."""
-        try:
-            topology = self._topology()
-        except (PeerRelationUnavailableError, PeerRelationNetworkUnavailableError) as err:
-            logger.info("Could not retrieve network topology: %s", err)
-            return
-        # If we are not the active unit, there's nothing to do
-        if not topology.is_current_unit_active:
-            return
-        relation_data = self._get_remote_relation_data()
-        if relation_data is None:
-            return
-        self.bind.update_zonefiles_and_reload(relation_data, topology)
+        self._reconcile()
 
-    def _on_dns_record_relation_changed(self, event: ops.RelationChangedEvent) -> None:
-        """Handle dns_record relation changed.
-
-        Args:
-            event: Event triggering the relation changed handler.
-
-        """
-        relation_data = self._get_remote_relation_data()
-        if relation_data is None:
-            return
-        self.unit.status = ops.MaintenanceStatus("Handling new relation requests")
-        dns_record_provider_data = dns_data.create_dns_record_provider_data(relation_data)
-        relation = self.model.get_relation(self.dns_record.relation_name, event.relation.id)
+    def _on_dns_record_relation_changed(self, _: ops.RelationChangedEvent) -> None:
+        """Handle dns_record relation changed."""
+        # Checking if we are the leader is also done in reconcile
+        # but doing it here avoids some unnecessary computations of reconcile for this case
         if self.unit.is_leader():
-            self.dns_record.update_relation_data(relation, dns_record_provider_data)
+            self._reconcile()
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
         """Handle collect status event.
@@ -163,10 +128,7 @@ class BindCharm(ops.CharmBase):
 
     def _on_leader_elected(self, _: ops.LeaderElectedEvent) -> None:
         """Handle leader-elected event."""
-        # We check that we are still the leader when starting to process this event
-        topology = self._topology()
-        if self.unit.is_leader() and not topology.is_current_unit_active:
-            self._check_and_may_become_active(topology)
+        self._reconcile()
 
     def _on_peer_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
         """Handle the peer relation departed event.
@@ -178,23 +140,7 @@ class BindCharm(ops.CharmBase):
         if event.departing_unit == self.model.unit:
             return
 
-        try:
-            topology = self._topology()
-        except (PeerRelationUnavailableError, PeerRelationNetworkUnavailableError) as err:
-            logger.info("Could not retrieve network topology: %s", err)
-            return
-
-        # We check that we are still the leader when starting to process this event
-        if not topology.is_current_unit_active:
-            if self.unit.is_leader():
-                self._check_and_may_become_active(topology)
-        else:
-            try:
-                relation_data = self.dns_record.get_remote_relation_data()
-            except ValueError as err:
-                logger.info("Validation error of the relation data: %s", err)
-                return
-            self.bind.update_zonefiles_and_reload(relation_data, topology)
+        self._reconcile()
 
     def _check_and_may_become_active(self, topology: models.Topology) -> bool:
         """Check the active unit status and may become active if need be.
@@ -312,6 +258,47 @@ class BindCharm(ops.CharmBase):
             "Relation data retrieval duration (ms): %s", (time.time_ns() - start_time) / 1e6
         )
         return relation_data
+
+    def _reconcile(self) -> None:  # noqa: C901
+        """Reconciles."""
+        # Retrieve the current topology of units
+        try:
+            topology = self._topology()
+        except (PeerRelationUnavailableError, PeerRelationNetworkUnavailableError) as err:
+            logger.info("Could not retrieve network topology: %s", err)
+            return
+
+        # If we're the leader and not active, check that the active unit is doing well
+        if self.unit.is_leader() and not topology.is_current_unit_active:
+            self._check_and_may_become_active(topology)
+
+        try:
+            relation_data = self.dns_record.get_remote_relation_data()
+        except ValueError as err:
+            logger.info("Validation error of the relation data: %s", err)
+            return
+
+        # If we're the active unit, update our config based on dns_record relation's data
+        # Non-active units replicate the config through zone transfer
+        if topology.is_current_unit_active:
+            try:
+                # Load the last valid state
+                last_valid_state = dns_data.load_state(
+                    pathlib.Path(constants.DNS_CONFIG_DIR, "state.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+            except FileNotFoundError:
+                # If we can't load the previous state,
+                # we assume that we need to regenerate the configuration
+                last_valid_state = {}
+            if dns_data.has_changed(relation_data, topology, last_valid_state):
+                self.bind.update_zonefiles_and_reload(relation_data, topology)
+
+        # Update dns_record relation's data if we are the leader
+        if self.unit.is_leader():
+            dns_record_provider_data = dns_data.create_dns_record_provider_data(relation_data)
+            self.dns_record.update_remote_relation_data(dns_record_provider_data)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/bind-operator/tests/unit/test_charm.py
+++ b/bind-operator/tests/unit/test_charm.py
@@ -7,6 +7,7 @@ import json
 import logging
 from unittest.mock import patch
 
+import ops
 import pytest
 import scenario
 from ops import testing
@@ -261,7 +262,10 @@ def test_dns_record_relation_changed_without_conflict(context, base_state):
             out_uuids = {x["uuid"] for x in data}
             # check that all the records from the requirer data are approved
             assert out_uuids == in_uuids
-    assert out.unit_status == testing.ActiveStatus()
+    # Only testing if the unit has an Active status without checking the status description
+    # This is done since we don't want to test if the unit reports as being the "active" one
+    # (it's not relevant to this test).
+    assert isinstance(out.unit_status, ops.ActiveStatus)
 
 
 @pytest.mark.usefixtures("context")


### PR DESCRIPTION
### Overview

`bind-operator` has become rather complicated. This is a first step in simplifying the charm, by adding a reconcile function to centralize the logic of handling events.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `docs/changelog.md` file was updated

<!-- Explanation for any unchecked items above -->
