### PR TITLE
Add dns_transfer library

### DIFF
--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -1,0 +1,532 @@
+# Copyright 2025 Canonical Ltd.
+# Licensed under the Apache2.0. See LICENSE file in charm source for details.
+# pylint: disable=R0801
+"""Library to manage the integration with the Bind charm.
+
+This library contains the Requires and Provides classes for handling the integration
+between an application and a charm providing the `dns_record` integration.
+
+### Requirer Charm
+
+```python
+
+from charms.dns_transfer.v0.dns_transfer import DNSTransferRequires
+
+class DNSTransferRequirerCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.dns_primary = DNSTransferRequires(self)
+        self.framework.observe(self.dns_primary.on.dns_transfer_provider_data_available, self._handler)
+        ...
+
+    def _handler(self, event: DNSTransferProviderDataAvailableEvent) -> None:
+        addresses = event.addresses
+        transport = event.transport
+        # or self.dns_primary.get_addresses() / self.dns_primary.get_transport()
+
+```
+
+As shown above, the library provides a custom event to handle the scenario in
+which new DNS data has been added or updated.
+
+The DNSTransferRequires provides an `update_relation_data` method to update the relation data by
+passing a list of IP addresses to the provider.
+
+### Provider Charm
+
+Following the previous example, this is an example of the provider charm.
+
+```python
+from charms.dns_transfer.v0.dns_transfer import DNSTransferProvides
+
+class DNSTransferProviderCharm(ops.CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.dns_secondary = DNSTransferProvides(self)
+        self.framework.observe(self.dns_secondaries.on.dns_transfer_requirer_data_available, self._handler)
+        ...
+
+    def _handler(self, event: DNSTransferRequirerDataAvailableEvent) -> None:
+        addresses = event.addresses
+        # or self.dns_secondary.get_addresses()
+
+```
+The DNSTransferProvides object wraps the list of relations into a `relations` property
+and provides an `update_relation_data` method to update the relation data by passing
+parameters with data expected by the requirer.
+
+```python
+class DNSTransferProviderCharm(ops.CharmBase):
+    ...
+
+    def _on_config_changed(self, _) -> None:
+        params = {
+            "addresses": ["10.20.30.40", "50.60.70.80"],
+            "transport": "tls",
+            "remote_hostname": "example.com",
+            "zones": ["zone1.com", "zone2.com"],
+        }
+        for relation in self.model.relations[self.dns_secondary.relation_name]:
+            self.dns_secondary.update_relation_data(relation, **params)
+
+```
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "908bcd1f0ad14cabbc9dca25fa0fc87c"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 5
+
+PYDEPS = ["pydantic>=2"]
+
+# pylint: disable=wrong-import-position
+import ipaddress
+import json
+import logging
+from enum import Enum
+from typing import Any, List, Optional, cast
+
+import ops
+import pydantic
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "dns-transfer"
+
+
+class TransportSecurity(str, Enum):
+    """Represent the transport security values.
+
+    Attributes:
+        TCP: tcp
+        TLS: tls
+    """
+
+    TCP = "tcp"
+    TLS = "tls"
+
+
+class DNSTransferProviderData(pydantic.BaseModel):
+    """List of information for the provider to manage and transfer.
+
+    Attributes:
+        addresses: IP list of the units composing the provider's deployment.
+        transport: Type of transport (tls or tcp).
+        remote_hostname: Advertised name of the host in the TLS certificate (optional).
+        zones: List of zone names.
+    """
+
+    addresses: list[pydantic.IPvAnyAddress]
+    transport: TransportSecurity
+    remote_hostname: Optional[str] = None
+    zones: list[str]
+
+    # pydantic wants 'self' as first argument
+    @pydantic.field_validator("addresses", mode="before")
+    def deduplicate_addresses(cls, v: Any) -> list:  # noqa: N805 pylint: disable=E0213
+        """Deduplicate addresses.
+
+        Args:
+            v: value
+
+        Returns:
+            list with unique values.
+        """
+        return list(set(v))
+
+    # pydantic wants 'self' as first argument
+    @pydantic.field_validator("zones", mode="before")
+    def deduplicate_zones(cls, v: Any) -> list:  # noqa: N805 pylint: disable=E0213
+        """Deduplicate zones.
+
+        Args:
+            v: value
+
+        Returns:
+            list with unique values.
+        """
+        return list(set(v))
+
+    def to_relation_data(self) -> dict[str, str]:
+        """Convert an instance of DNSTransferProviderData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        dumped_model = self.model_dump(exclude_unset=True)
+        dumped_data = {}
+        for key, value in dumped_model.items():
+            dumped_data[key] = json.dumps(value, default=str)
+        return dumped_data
+
+    @classmethod
+    def from_relation_data(cls, relation: ops.Relation) -> "DNSTransferProviderData":
+        """Initialize a new instance of the DNSTransferProviderData class from the relation.
+
+        Args:
+            relation: the relation.
+
+        Returns:
+            A DNSTransferProviderData instance.
+
+        Raises:
+            ValueError: if the value is not parseable.
+        """
+        try:
+            loaded_data = {}
+            app = cast(ops.Application, relation.app)
+            relation_data = relation.data[app]
+            for key, value in relation_data.items():
+                loaded_data[key] = json.loads(value)
+            return DNSTransferProviderData.model_validate(loaded_data)
+        except json.JSONDecodeError as ex:
+            raise ValueError from ex
+
+
+class DNSTransferRequirerData(pydantic.BaseModel):
+    """List of information for the requirer to manage and transfer.
+
+    Attributes:
+        addresses: IP list of the units composing the provider's deployment.
+    """
+
+    addresses: list[pydantic.IPvAnyAddress]
+
+    # pydantic wants 'self' as first argument
+    @pydantic.field_validator("addresses", mode="before")
+    def deduplicate_addresses(cls, v: Any) -> list:  # noqa: N805 pylint: disable=E0213
+        """Deduplicate addresses.
+
+        Args:
+            v: value
+
+        Returns:
+            list with unique values.
+        """
+        return list(set(v))
+
+    def to_relation_data(self) -> dict[str, str]:
+        """Convert an instance of DNSTransferRequirerData to the relation representation.
+
+        Returns:
+            Dict containing the representation.
+        """
+        return {"addresses": json.dumps(self.addresses, default=str)}
+
+    @classmethod
+    def from_relation_data(cls, relation: ops.Relation) -> "DNSTransferRequirerData":
+        """Initialize a new instance of the DNSTransferRequirerData class from the relation.
+
+        Args:
+            relation: the relation.
+
+        Returns:
+            A DNSTransferRequirerData instance.
+
+        Raises:
+            ValueError: if the value is not parseable.
+        """
+        try:
+            loaded_data = {}
+            app = cast(ops.Application, relation.app)
+            relation_data = relation.data[app]
+            for key, value in relation_data.items():
+                loaded_data[key] = json.loads(value)
+            return DNSTransferRequirerData.model_validate(loaded_data)
+        except json.JSONDecodeError as ex:
+            raise ValueError from ex
+
+
+class DNSTransferRequirerDataAvailableEvent(ops.RelationEvent):
+    """DNSTransfer event emitted when relation data has changed by requirer.
+
+    Attrs:
+        dns_transfer_relation_data: dns transfer relation data.
+        addresses: the ips of the units of the requirer.
+    """
+
+    @property
+    def dns_transfer_relation_data(self) -> DNSTransferRequirerData:
+        """Get a DNSTransferRequirerData for the relation data."""
+        assert self.relation.app
+        return DNSTransferRequirerData.from_relation_data(self.relation)
+
+    @property
+    def addresses(self) -> list[pydantic.IPvAnyAddress]:
+        """Get the addresses from the relation data."""
+        return self.dns_transfer_relation_data.addresses
+
+
+class DNSTransferRequiresEvents(ops.CharmEvents):
+    """DNS transfer requirer events.
+
+    This class defines the events that a DNS transfer requirer can emit.
+
+    Attributes:
+        dns_transfer_requirer_data_available: the DNSTransferRequirerDataAvailable.
+    """
+
+    dns_transfer_requirer_data_available = ops.EventSource(DNSTransferRequirerDataAvailableEvent)
+
+
+class DNSTransferRequires(ops.Object):
+    """Requirer side of the DNS transfer requires relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = DNSTransferRequiresEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_remote_relation_data(self) -> DNSTransferProviderData | None:
+        """Retrieve the remote relation data.
+
+        Returns:
+            DNSTransferProviderData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        if not relation:
+            return None
+        return DNSTransferProviderData.from_relation_data(relation) if relation else None
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        app = event.relation.app
+        if app is None:
+            logger.warning(
+                "RelationChangedEvent: event.relation.app is not defined. Skipping data processing."
+            )
+            return
+
+        try:
+            _: DNSTransferProviderData = DNSTransferProviderData.from_relation_data(event.relation)
+        except ValueError as ex:
+            logger.warning("Failed to parse remote relation data: %s", ex)
+            return
+
+        self.on.dns_transfer_provider_data_available.emit(
+            event.relation, app=event.app, unit=event.unit
+        )
+
+    def update_relation_data(
+        self,
+        relation: ops.Relation,
+        *,
+        addresses: list[str],
+    ) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation for which to update the data.
+            addresses: address list e.g. [10.20.30.40, 50.60.70.80].
+        """
+        addresses_as_ips = [ipaddress.ip_address(addr) for addr in addresses]
+        dns_transfer_requirer_data = DNSTransferRequirerData(addresses=addresses_as_ips)
+        relation_data = dns_transfer_requirer_data.to_relation_data()
+        relation.data[self.charm.model.app].update(relation_data)
+
+    # Public accessors for remote relation data
+    def get_addresses(self) -> List[str]:
+        """Return a list of IP addresses from the provider, as strings.
+
+        Returns:
+            A list of IP address strings, or an empty list if no valid data is found.
+        """
+        data: DNSTransferProviderData | None = self.get_remote_relation_data()
+        return [str(ip) for ip in data.addresses] if data else []
+
+    def get_transport(self) -> Optional[str]:
+        """Return the transport protocol used by the provider.
+
+        Returns:
+            The transport string ("tcp" or "tls"), or None if unavailable.
+        """
+        data: DNSTransferProviderData | None = self.get_remote_relation_data()
+        return data.transport.value if data else None
+
+    def get_remote_hostname(self) -> Optional[str]:
+        """Return the remote hostname advertised in the provider's TLS certificate.
+
+        Returns:
+            The remote hostname string, or None if not set.
+        """
+        data: DNSTransferProviderData | None = self.get_remote_relation_data()
+        return data.remote_hostname if data else None
+
+    def get_zones(self) -> List[str]:
+        """Return the list of DNS zones managed by the provider.
+
+        Returns:
+            A list of zone name strings, or an empty list if no valid data is found.
+        """
+        data: DNSTransferProviderData | None = self.get_remote_relation_data()
+        return data.zones if data else []
+
+
+class DNSTransferProviderDataAvailableEvent(ops.RelationEvent):
+    """DNSTransfer event emitted when relation data has changed by provider.
+
+    Attrs:
+        dns_transfer_relation_data: dns transfer relation data.
+        addresses: IP list of the units composing the provider's deployment.
+        transport: Type of transport (tls or tcp).
+        remote_hostname: Advertised name of the host in the TLS certificate (optional).
+        zones: List of zone names.
+    """
+
+    @property
+    def dns_transfer_relation_data(self) -> DNSTransferProviderData:
+        """Get a DNSTransferRequirerData for the relation data."""
+        assert self.relation.app
+        return DNSTransferProviderData.from_relation_data(self.relation)
+
+    @property
+    def addresses(self) -> list[pydantic.IPvAnyAddress]:
+        """Get the addresses from the relation data."""
+        return self.dns_transfer_relation_data.addresses
+
+    @property
+    def transport(self) -> TransportSecurity:
+        """Get the transport from the relation data."""
+        return self.dns_transfer_relation_data.transport
+
+    @property
+    def remote_hostname(self) -> Optional[str]:
+        """Get the remote hostname from the relation data."""
+        return self.dns_transfer_relation_data.remote_hostname
+
+    @property
+    def zones(self) -> list[str]:
+        """Get the zones from the relation data."""
+        return self.dns_transfer_relation_data.zones
+
+
+class DNSTransferProvidesEvents(ops.CharmEvents):
+    """DNS transfer provider events.
+
+    This class defines the events that a DNS transfer provider can emit.
+
+    Attributes:
+        dns_transfer_provider_data_available: the DNSTransferProviderData.
+    """
+
+    dns_transfer_provider_data_available = ops.EventSource(DNSTransferProviderDataAvailableEvent)
+
+
+class DNSTransferProvides(ops.Object):
+    """Provider side of the DNS transfer relation.
+
+    Attributes:
+        on: events the provider can emit.
+    """
+
+    on = DNSTransferProvidesEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def get_remote_relation_data(self) -> DNSTransferRequirerData | None:
+        """Retrieve the remote relation data.
+
+        Returns:
+            DNSTransferProviderData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        if not relation:
+            return None
+        return DNSTransferRequirerData.from_relation_data(relation) if relation else None
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed.
+
+        Args:
+            event: event triggering this handler.
+        """
+        app = event.relation.app
+        if app is None:
+            logger.warning(
+                "RelationChangedEvent: event.relation.app is not defined. Skipping data processing."
+            )
+            return
+
+        try:
+            _: DNSTransferRequirerData = DNSTransferRequirerData.from_relation_data(event.relation)
+        except ValueError as ex:
+            logger.warning("Failed to parse remote relation data: %s", ex)
+            return
+
+        self.on.dns_transfer_requirer_data_available.emit(
+            event.relation, app=event.app, unit=event.unit
+        )
+
+    def update_relation_data(
+        self,
+        relation: ops.Relation,
+        *,
+        addresses: List[str],
+        transport: str = "tls",
+        remote_hostname: Optional[str] = None,
+        zones: List[str],
+    ) -> None:
+        """Update the relation data.
+
+        Args:
+            relation: the relation to update.
+            addresses: list of IP address strings.
+            transport: transport protocol string, defaults to "tls".
+            remote_hostname: optional TLS hostname string.
+            zones: list of DNS zone strings.
+        """
+        ip_addresses = [ipaddress.ip_address(addr) for addr in addresses]
+        transport_val = TransportSecurity(transport)
+
+        dns_record_provider_data = DNSTransferProviderData(
+            addresses=ip_addresses,
+            transport=transport_val,
+            remote_hostname=remote_hostname,
+            zones=zones,
+        )
+        relation_data = dns_record_provider_data.to_relation_data()
+        relation.data[self.charm.model.app].update(relation_data)
+
+    # Public accessors for remote relation data
+    def get_addresses(self) -> List[str]:
+        """Return a list of IP addresses from the provider, as strings.
+
+        Returns:
+            A list of address strings, or an empty list if no valid data is found.
+        """
+        data: DNSTransferRequirerData | None = self.get_remote_relation_data()
+        if not data:
+            return []
+        return [str(ip) for ip in data.addresses]

--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -59,10 +59,12 @@ class DNSTransferProviderCharm(ops.CharmBase):
             addresses.extend(dns_secondary_data.addresses)
 
     def _on_config_changed(self, event: ops.Event) -> None:
-        provider_data = DNSTransferProviderData()
-        provider_data.addresses = self.addresses()
-        provider_data.transport = self.transport()
-        provider_data.zones = self.zones()
+        data = {
+            "addresses": self.addresses(),
+            "transport": self.transport(),
+            "zones": self.zones(),
+        }
+        provider_data = DNSTransferProviderData.model_validate(data)
         for relation in self.model.relations[self.dns_transfer.relation_name]:
             self.dns_transfer.update_relation_data(relation, provider_data)
 

--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -1,73 +1,70 @@
 # Copyright 2025 Canonical Ltd.
 # Licensed under the Apache2.0. See LICENSE file in charm source for details.
 # pylint: disable=R0801
-"""Library to manage the integration with the Bind charm.
+"""Library to manage the integration between primary and secondary DNS charms.
 
 This library contains the Requires and Provides classes for handling the integration
 between an application and a charm providing the `dns_record` integration.
 
 ### Requirer Charm
 
+The DNSTransferRequires provides:
+
+* an `get_remote_relation_data" method to get data from the provider.
+* an `update_relation_data` method to update the relation data by
+passing a list of IP addresses to the provider.
+
 ```python
 
-from charms.dns_transfer.v0.dns_transfer import DNSTransferRequires
+from charms.dns_transfer.v0.dns_transfer import DNSTransferRequires, DNSTransferRequirerData
 
 class DNSTransferRequirerCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.dns_primary = DNSTransferRequires(self)
-        self.framework.observe(self.dns_primary.on.dns_transfer_provider_data_available, self._handler)
+        self.dns_transfer = DNSTransferRequires(self)
+        # line-too-long
+        self.framework.observe(charm.on["dns-transfer"].relation_changed, self._on_relation_changed) # noqa: W505 pylint: disable=C0301
         ...
 
-    def _handler(self, event: DNSTransferProviderDataAvailableEvent) -> None:
-        addresses = event.addresses
-        transport = event.transport
-        # or self.dns_primary.get_addresses() / self.dns_primary.get_transport()
+    def _on_relation_changed(self, event: ops.Event) -> None:
+        dns_primary_data = self.dns_transfer.get_remote_relation_data()
+        addresses = dns_primary_data.addresses
+
+    def _on_config_changed(self, event: ops.Event) -> None:
+        addresses = self.my_ips()
+        relation = self.model.get_relation(self.dns_transfer.relation_name)
+        requirer_data = DNSTransferRequirerData(addresses=addresses)
+        self.dns_transfer.update_relation_data(relation, requirer_data)
 
 ```
-
-As shown above, the library provides a custom event to handle the scenario in
-which new DNS data has been added or updated.
-
-The DNSTransferRequires provides an `update_relation_data` method to update the relation data by
-passing a list of IP addresses to the provider.
 
 ### Provider Charm
 
 Following the previous example, this is an example of the provider charm.
 
 ```python
-from charms.dns_transfer.v0.dns_transfer import DNSTransferProvides
+from charms.dns_transfer.v0.dns_transfer import DNSTransferProvides, DNSTransferProviderData
 
 class DNSTransferProviderCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.dns_secondary = DNSTransferProvides(self)
-        self.framework.observe(self.dns_secondaries.on.dns_transfer_requirer_data_available, self._handler)
+        self.dns_transfer = DNSTransferProvides(self)
+        self.framework.observe(charm.on["dns-transfer"].relation_changed, self._on_relation_changed)
         ...
 
-    def _handler(self, event: DNSTransferRequirerDataAvailableEvent) -> None:
-        addresses = event.addresses
-        # or self.dns_secondary.get_addresses()
+    def _on_relation_changed(self, event: ops.Event) -> None:
+        addresses = []
+        for relation in self.model.relations[self.dns_transfer.relation_name]:
+            dns_secondary_data = self.dns_transfer.get_remote_relation_data(relation)
+            addresses.extend(dns_secondary_data.addresses)
 
-```
-The DNSTransferProvides object wraps the list of relations into a `relations` property
-and provides an `update_relation_data` method to update the relation data by passing
-parameters with data expected by the requirer.
-
-```python
-class DNSTransferProviderCharm(ops.CharmBase):
-    ...
-
-    def _on_config_changed(self, _) -> None:
-        params = {
-            "addresses": ["10.20.30.40", "50.60.70.80"],
-            "transport": "tls",
-            "remote_hostname": "example.com",
-            "zones": ["zone1.com", "zone2.com"],
-        }
-        for relation in self.model.relations[self.dns_secondary.relation_name]:
-            self.dns_secondary.update_relation_data(relation, **params)
+    def _on_config_changed(self, event: ops.Event) -> None:
+        provider_data = DNSTransferProviderData()
+        provider_data.addresses = self.addresses()
+        provider_data.transport = self.transport()
+        provider_data.zones = self.zones()
+        for relation in self.model.relations[self.dns_transfer.relation_name]:
+            self.dns_transfer.update_relation_data(relation, provider_data)
 
 ```
 """
@@ -85,11 +82,10 @@ LIBPATCH = 5
 PYDEPS = ["pydantic>=2"]
 
 # pylint: disable=wrong-import-position
-import ipaddress
 import json
 import logging
 from enum import Enum
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
 import ops
 import pydantic
@@ -242,46 +238,8 @@ class DNSTransferRequirerData(pydantic.BaseModel):
             raise ValueError from ex
 
 
-class DNSTransferRequirerDataAvailableEvent(ops.RelationEvent):
-    """DNSTransfer event emitted when relation data has changed by requirer.
-
-    Attrs:
-        dns_transfer_relation_data: dns transfer relation data.
-        addresses: the ips of the units of the requirer.
-    """
-
-    @property
-    def dns_transfer_relation_data(self) -> DNSTransferRequirerData:
-        """Get a DNSTransferRequirerData for the relation data."""
-        assert self.relation.app
-        return DNSTransferRequirerData.from_relation_data(self.relation)
-
-    @property
-    def addresses(self) -> list[pydantic.IPvAnyAddress]:
-        """Get the addresses from the relation data."""
-        return self.dns_transfer_relation_data.addresses
-
-
-class DNSTransferRequiresEvents(ops.CharmEvents):
-    """DNS transfer requirer events.
-
-    This class defines the events that a DNS transfer requirer can emit.
-
-    Attributes:
-        dns_transfer_requirer_data_available: the DNSTransferRequirerDataAvailable.
-    """
-
-    dns_transfer_requirer_data_available = ops.EventSource(DNSTransferRequirerDataAvailableEvent)
-
-
 class DNSTransferRequires(ops.Object):
-    """Requirer side of the DNS transfer requires relation.
-
-    Attributes:
-        on: events the provider can emit.
-    """
-
-    on = DNSTransferRequiresEvents()
+    """Requirer side of the DNS transfer requires relation."""
 
     def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
         """Construct.
@@ -293,7 +251,6 @@ class DNSTransferRequires(ops.Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
-        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def get_remote_relation_data(self) -> DNSTransferProviderData | None:
         """Retrieve the remote relation data.
@@ -306,142 +263,24 @@ class DNSTransferRequires(ops.Object):
             return None
         return DNSTransferProviderData.from_relation_data(relation) if relation else None
 
-    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed.
-
-        Args:
-            event: event triggering this handler.
-        """
-        app = event.relation.app
-        if app is None:
-            logger.warning(
-                "RelationChangedEvent: event.relation.app is not defined. Skipping data processing."
-            )
-            return
-
-        try:
-            _: DNSTransferProviderData = DNSTransferProviderData.from_relation_data(event.relation)
-        except ValueError as ex:
-            logger.warning("Failed to parse remote relation data: %s", ex)
-            return
-
-        self.on.dns_transfer_provider_data_available.emit(
-            event.relation, app=event.app, unit=event.unit
-        )
-
     def update_relation_data(
         self,
         relation: ops.Relation,
-        *,
-        addresses: list[str],
+        requirer_data: DNSTransferRequirerData,
     ) -> None:
         """Update the relation data.
 
         Args:
             relation: the relation for which to update the data.
-            addresses: address list e.g. [10.20.30.40, 50.60.70.80].
+            requirer_data: data as DNSTransferRequirerData.
         """
-        addresses_as_ips = [ipaddress.ip_address(addr) for addr in addresses]
-        dns_transfer_requirer_data = DNSTransferRequirerData(addresses=addresses_as_ips)
-        relation_data = dns_transfer_requirer_data.to_relation_data()
-        relation.data[self.charm.model.app].update(relation_data)
-
-    # Public accessors for remote relation data
-    def get_addresses(self) -> List[str]:
-        """Return a list of IP addresses from the provider, as strings.
-
-        Returns:
-            A list of IP address strings, or an empty list if no valid data is found.
-        """
-        data: DNSTransferProviderData | None = self.get_remote_relation_data()
-        return [str(ip) for ip in data.addresses] if data else []
-
-    def get_transport(self) -> Optional[str]:
-        """Return the transport protocol used by the provider.
-
-        Returns:
-            The transport string ("tcp" or "tls"), or None if unavailable.
-        """
-        data: DNSTransferProviderData | None = self.get_remote_relation_data()
-        return data.transport.value if data else None
-
-    def get_remote_hostname(self) -> Optional[str]:
-        """Return the remote hostname advertised in the provider's TLS certificate.
-
-        Returns:
-            The remote hostname string, or None if not set.
-        """
-        data: DNSTransferProviderData | None = self.get_remote_relation_data()
-        return data.remote_hostname if data else None
-
-    def get_zones(self) -> List[str]:
-        """Return the list of DNS zones managed by the provider.
-
-        Returns:
-            A list of zone name strings, or an empty list if no valid data is found.
-        """
-        data: DNSTransferProviderData | None = self.get_remote_relation_data()
-        return data.zones if data else []
-
-
-class DNSTransferProviderDataAvailableEvent(ops.RelationEvent):
-    """DNSTransfer event emitted when relation data has changed by provider.
-
-    Attrs:
-        dns_transfer_relation_data: dns transfer relation data.
-        addresses: IP list of the units composing the provider's deployment.
-        transport: Type of transport (tls or tcp).
-        remote_hostname: Advertised name of the host in the TLS certificate (optional).
-        zones: List of zone names.
-    """
-
-    @property
-    def dns_transfer_relation_data(self) -> DNSTransferProviderData:
-        """Get a DNSTransferRequirerData for the relation data."""
-        assert self.relation.app
-        return DNSTransferProviderData.from_relation_data(self.relation)
-
-    @property
-    def addresses(self) -> list[pydantic.IPvAnyAddress]:
-        """Get the addresses from the relation data."""
-        return self.dns_transfer_relation_data.addresses
-
-    @property
-    def transport(self) -> TransportSecurity:
-        """Get the transport from the relation data."""
-        return self.dns_transfer_relation_data.transport
-
-    @property
-    def remote_hostname(self) -> Optional[str]:
-        """Get the remote hostname from the relation data."""
-        return self.dns_transfer_relation_data.remote_hostname
-
-    @property
-    def zones(self) -> list[str]:
-        """Get the zones from the relation data."""
-        return self.dns_transfer_relation_data.zones
-
-
-class DNSTransferProvidesEvents(ops.CharmEvents):
-    """DNS transfer provider events.
-
-    This class defines the events that a DNS transfer provider can emit.
-
-    Attributes:
-        dns_transfer_provider_data_available: the DNSTransferProviderData.
-    """
-
-    dns_transfer_provider_data_available = ops.EventSource(DNSTransferProviderDataAvailableEvent)
+        if not relation:
+            return
+        relation.data[self.charm.model.app].update(requirer_data.to_relation_data())
 
 
 class DNSTransferProvides(ops.Object):
-    """Provider side of the DNS transfer relation.
-
-    Attributes:
-        on: events the provider can emit.
-    """
-
-    on = DNSTransferProvidesEvents()
+    """Provider side of the DNS transfer relation."""
 
     def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
         """Construct.
@@ -453,80 +292,31 @@ class DNSTransferProvides(ops.Object):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
-        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
-    def get_remote_relation_data(self) -> DNSTransferRequirerData | None:
+    def get_remote_relation_data(self, relation: ops.Relation) -> DNSTransferRequirerData | None:
         """Retrieve the remote relation data.
+
+        Args:
+            relation: the relation to get data from.
 
         Returns:
             DNSTransferProviderData: the relation data.
         """
-        relation = self.model.get_relation(self.relation_name)
         if not relation:
             return None
         return DNSTransferRequirerData.from_relation_data(relation) if relation else None
 
-    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed.
-
-        Args:
-            event: event triggering this handler.
-        """
-        app = event.relation.app
-        if app is None:
-            logger.warning(
-                "RelationChangedEvent: event.relation.app is not defined. Skipping data processing."
-            )
-            return
-
-        try:
-            _: DNSTransferRequirerData = DNSTransferRequirerData.from_relation_data(event.relation)
-        except ValueError as ex:
-            logger.warning("Failed to parse remote relation data: %s", ex)
-            return
-
-        self.on.dns_transfer_requirer_data_available.emit(
-            event.relation, app=event.app, unit=event.unit
-        )
-
     def update_relation_data(
         self,
         relation: ops.Relation,
-        *,
-        addresses: List[str],
-        transport: str = "tls",
-        remote_hostname: Optional[str] = None,
-        zones: List[str],
+        provider_data: DNSTransferProviderData,
     ) -> None:
         """Update the relation data.
 
         Args:
             relation: the relation to update.
-            addresses: list of IP address strings.
-            transport: transport protocol string, defaults to "tls".
-            remote_hostname: optional TLS hostname string.
-            zones: list of DNS zone strings.
+            provider_data: data as DNSTransferProviderData.
         """
-        ip_addresses = [ipaddress.ip_address(addr) for addr in addresses]
-        transport_val = TransportSecurity(transport)
-
-        dns_record_provider_data = DNSTransferProviderData(
-            addresses=ip_addresses,
-            transport=transport_val,
-            remote_hostname=remote_hostname,
-            zones=zones,
-        )
-        relation_data = dns_record_provider_data.to_relation_data()
-        relation.data[self.charm.model.app].update(relation_data)
-
-    # Public accessors for remote relation data
-    def get_addresses(self) -> List[str]:
-        """Return a list of IP addresses from the provider, as strings.
-
-        Returns:
-            A list of address strings, or an empty list if no valid data is found.
-        """
-        data: DNSTransferRequirerData | None = self.get_remote_relation_data()
-        if not data:
-            return []
-        return [str(ip) for ip in data.addresses]
+        if not relation:
+            return
+        relation.data[self.charm.model.app].update(provider_data.to_relation_data())

--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -269,7 +269,7 @@ class DNSTransferRequires(ops.Object):
         """Construct.
 
         Args:
-            charm: the provider charm.
+            charm: the requirer charm.
             relation_name: the relation name.
         """
         super().__init__(charm, relation_name)

--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -156,10 +156,10 @@ class DNSTransferProviderData(pydantic.BaseModel):
         """Deduplicate zones.
 
         Args:
-            v: value
+            v: The input value provided for the `remote_hostname` field.
 
         Returns:
-            hostname.
+            A validated hostname.
 
         Raises:
             ValueError: if hostname is not RFC 952 valid name.

--- a/lib/charms/dns_transfer/v0/dns_transfer.py
+++ b/lib/charms/dns_transfer/v0/dns_transfer.py
@@ -153,7 +153,7 @@ class DNSTransferProviderData(pydantic.BaseModel):
     # pydantic wants 'self' as first argument
     @pydantic.field_validator("remote_hostname")
     def validate_hostname(cls, v: Any) -> Any:  # noqa: N805 pylint: disable=E0213
-        """Deduplicate zones.
+        """Validate hostname against RFC 952
 
         Args:
             v: The input value provided for the `remote_hostname` field.

--- a/lib/tests/unit/conftest.py
+++ b/lib/tests/unit/conftest.py
@@ -3,6 +3,71 @@
 
 """Fixtures for charm tests."""
 
+import json
 import logging
+from typing import Any, Generator
+
+import pytest
+from ops import testing
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function", name="dns_transfer_requirer_remote_data")
+def dns_transfer_requirer_remote_data_fixture() -> Generator[dict[str, str], Any, None]:
+    """Fixture for requirer remote data.
+
+    Yields:
+        Relation data in json format.
+    """
+    yield {
+        "addresses": json.dumps(["10.10.10.10"]),
+        "zones": json.dumps(["example.com"]),
+        "transport": json.dumps("tls"),
+    }
+
+
+@pytest.fixture(scope="function", name="dns_transfer_requirer_relation")
+def dns_transfer_requirer_relation_fixture(
+    dns_transfer_requirer_remote_data,
+) -> Generator[Any, Any, None]:
+    """Fixture for requirer relation.
+
+    Yields:
+        Relation.
+    """
+    yield testing.Relation(
+        endpoint="dns-transfer",
+        interface="dns-transfer",
+        remote_app_name="primary",
+        remote_app_data=dns_transfer_requirer_remote_data,
+    )
+
+
+@pytest.fixture(scope="function", name="dns_transfer_provider_remote_data")
+def dns_transfer_provider_remote_data_fixture() -> Generator[dict[str, str], Any, None]:
+    """Fixture for provider remote data.
+
+    Yields:
+        Relation data in json format.
+    """
+    yield {
+        "addresses": json.dumps(["10.10.10.20"]),
+    }
+
+
+@pytest.fixture(scope="function", name="dns_transfer_provider_relation")
+def dns_transfer_provider_relation_fixture(
+    dns_transfer_provider_remote_data,
+) -> Generator[Any, Any, None]:
+    """Fixture for provider relation..
+
+    Yields:
+        Relation.
+    """
+    yield testing.Relation(
+        endpoint="dns-transfer",
+        interface="dns-transfer",
+        remote_app_name="secondary",
+        remote_app_data=dns_transfer_provider_remote_data,
+    )

--- a/lib/tests/unit/test_library_dns_transfer.py
+++ b/lib/tests/unit/test_library_dns_transfer.py
@@ -3,9 +3,10 @@
 
 """DNS transfer library unit tests"""
 
-import json
+import ipaddress
 
 import ops
+import yaml
 from ops import testing
 
 from charms.dns_transfer.v0 import dns_transfer
@@ -24,6 +25,10 @@ provides:
     interface: dns-transfer
 """
 
+REQUIRER_UPDATE_DATA_ADDRESSES = "10.10.10.30"
+PROVIDER_UPDATE_DATA_ADDRESSES = "10.10.10.20"
+PROVIDER_UPDATE_DATA_ZONES = "first.example.com"
+
 
 class DNSTransferRequirerCharm(ops.CharmBase):
     """Class for requirer charm testing."""
@@ -36,23 +41,16 @@ class DNSTransferRequirerCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.dns_transfer = dns_transfer.DNSTransferRequires(self)
-        self.framework.observe(self.on["dns-transfer"].relation_changed, self._record_event)
         self.framework.observe(self.on.config_changed, self._reconcile)
-
-    def _record_event(self, event: ops.EventBase) -> None:
-        """Record emitted event in the event list.
-
-        Args:
-            event: event.
-        """
-        # mypy warns us that we can import different types of events doing that.
-        # We know mypy, we know.
-        self.events.append(event)  # type: ignore # pylint: disable=no-member
 
     def _reconcile(self, _: ops.EventBase) -> None:
         """Reconcile charm."""
-        print("Reconcile")
-        # self.dns_transfer.update_relation_data()
+        relation = self.model.get_relation(self.dns_transfer.relation_name)
+        requirer_data = dns_transfer.DNSTransferRequirerData(
+            addresses=[ipaddress.IPv4Address(REQUIRER_UPDATE_DATA_ADDRESSES)]
+        )
+        if relation:
+            self.dns_transfer.update_relation_data(relation, requirer_data)
 
 
 class DNSTransferProviderCharm(ops.CharmBase):
@@ -66,26 +64,21 @@ class DNSTransferProviderCharm(ops.CharmBase):
         """
         super().__init__(*args)
         self.dns_transfer = dns_transfer.DNSTransferProvides(self)
-        self.framework.observe(self.on["dns-transfer"].relation_changed, self._record_event)
         self.framework.observe(self.on.config_changed, self._reconcile)
-
-    def _record_event(self, event: ops.EventBase) -> None:
-        """Record emitted event in the event list.
-
-        Args:
-            event: event.
-        """
-        # mypy warns us that we can import different types of events doing that.
-        # We know mypy, we know.
-        self.events.append(event)  # type: ignore # pylint: disable=no-member
 
     def _reconcile(self, _: ops.EventBase) -> None:
         """Reconcile charm."""
-        print("Reconcile")
-        # self.dns_transfer.update_relation_data()
+        provider_data = dns_transfer.DNSTransferProviderData(
+            addresses=[ipaddress.IPv4Address(PROVIDER_UPDATE_DATA_ADDRESSES)],
+            transport=dns_transfer.TransportSecurity.TLS,
+            remote_hostname=None,
+            zones=[PROVIDER_UPDATE_DATA_ZONES],
+        )
+        for relation in self.model.relations[self.dns_transfer.relation_name]:
+            self.dns_transfer.update_relation_data(relation, provider_data)
 
 
-def test_requirer_get_relation_data():
+def test_dns_transfer_requirer_get_relation_data(dns_transfer_requirer_relation):
     """
     arrange: given a requirer charm.
     act: add the relation data.
@@ -93,30 +86,83 @@ def test_requirer_get_relation_data():
     """
     ctx = testing.Context(
         DNSTransferRequirerCharm,
-        meta={
-            "name": "dns-transfer-secondary",
-            "provides": {"dns-transfer": {"interface": "dns-transfer"}},
-        },
+        meta=yaml.safe_load(REQUIRER_METADATA),
     )
-    rel = testing.Relation(
-        endpoint="dns-transfer",
-        interface="dns-transfer",
-        remote_app_name="primary",
-        remote_app_data={
-            "addresses": json.dumps(["10.10.10.10"]),
-            "zones": json.dumps(["example.com"]),
-            "transport": json.dumps("tls"),
-        },
-    )
-    state = testing.State(relations={rel})
+    state = testing.State(relations=[dns_transfer_requirer_relation])
 
     with ctx(ctx.on.start(), state) as manager:
         assert (
             manager.charm.dns_transfer.get_remote_relation_data()
             == dns_transfer.DNSTransferProviderData(
-                addresses=["10.10.10.10"],  # type: ignore[list-item]
-                transport="tls",  # type: ignore[arg-type]
+                addresses=[ipaddress.IPv4Address("10.10.10.10")],
+                transport=dns_transfer.TransportSecurity.TLS,
                 remote_hostname=None,
                 zones=["example.com"],
             )
         )
+
+
+def test_dns_transfer_requirer_update_relation_data(dns_transfer_requirer_relation):
+    """
+    arrange: given a requirer charm.
+    act: add the relation data and trigger a change via config-changed event.
+    assert: the local relation data matches the one provided.
+    """
+    ctx = testing.Context(
+        DNSTransferRequirerCharm,
+        meta=yaml.safe_load(REQUIRER_METADATA),
+    )
+    state = testing.State(relations=[dns_transfer_requirer_relation], leader=True)
+
+    with ctx(ctx.on.config_changed(), state) as manager:
+        state_out = manager.run()
+        relation = next(
+            r for r in state_out.relations if r.endpoint == dns_transfer.DEFAULT_RELATION_NAME
+        )
+        assert relation.local_app_data == {"addresses": f'["{REQUIRER_UPDATE_DATA_ADDRESSES}"]'}
+
+
+def test_dns_transfer_provider_get_relation_data(dns_transfer_provider_relation):
+    """
+    arrange: given a provider charm.
+    act: add the relation data.
+    assert: the relation data matches the one provided.
+    """
+    ctx = testing.Context(
+        DNSTransferProviderCharm,
+        meta=yaml.safe_load(PROVIDER_METADATA),
+    )
+    state = testing.State(relations=[dns_transfer_provider_relation])
+
+    with ctx(ctx.on.start(), state) as manager:
+        relation = manager.charm.model.relations["dns-transfer"][0]
+        assert manager.charm.dns_transfer.get_remote_relation_data(
+            relation
+        ) == dns_transfer.DNSTransferRequirerData(
+            addresses=[ipaddress.IPv4Address("10.10.10.20")],
+        )
+
+
+def test_dns_transfer_provider_update_relation_data(dns_transfer_provider_relation):
+    """
+    arrange: given a provider charm.
+    act: add the relation data and trigger a change via config-changed event.
+    assert: the local relation data matches the one provided.
+    """
+    ctx = testing.Context(
+        DNSTransferProviderCharm,
+        meta=yaml.safe_load(PROVIDER_METADATA),
+    )
+    state = testing.State(relations=[dns_transfer_provider_relation], leader=True)
+
+    with ctx(ctx.on.config_changed(), state) as manager:
+        state_out = manager.run()
+        relation = next(
+            r for r in state_out.relations if r.endpoint == dns_transfer.DEFAULT_RELATION_NAME
+        )
+        assert relation.local_app_data == {
+            "addresses": f'["{PROVIDER_UPDATE_DATA_ADDRESSES}"]',
+            "zones": f'["{PROVIDER_UPDATE_DATA_ZONES}"]',
+            "transport": '"tls"',
+            "remote_hostname": "null",
+        }

--- a/lib/tests/unit/test_library_dns_transfer.py
+++ b/lib/tests/unit/test_library_dns_transfer.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""DNS transfer library unit tests"""
+
+import json
+
+import ops
+from ops import testing
+
+from charms.dns_transfer.v0 import dns_transfer
+
+REQUIRER_METADATA = """
+name: dns-transfer-secondary
+requires:
+  dns-transfer:
+    interface: dns-transfer
+"""
+
+PROVIDER_METADATA = """
+name: dns-transfer-primary
+provides:
+  dns-transfer:
+    interface: dns-transfer
+"""
+
+
+class DNSTransferRequirerCharm(ops.CharmBase):
+    """Class for requirer charm testing."""
+
+    def __init__(self, *args):
+        """Init method for the class.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.dns_transfer = dns_transfer.DNSTransferRequires(self)
+        self.framework.observe(self.on["dns-transfer"].relation_changed, self._record_event)
+        self.framework.observe(self.on.config_changed, self._reconcile)
+
+    def _record_event(self, event: ops.EventBase) -> None:
+        """Record emitted event in the event list.
+
+        Args:
+            event: event.
+        """
+        # mypy warns us that we can import different types of events doing that.
+        # We know mypy, we know.
+        self.events.append(event)  # type: ignore # pylint: disable=no-member
+
+    def _reconcile(self, _: ops.EventBase) -> None:
+        """Reconcile charm."""
+        print("Reconcile")
+        # self.dns_transfer.update_relation_data()
+
+
+class DNSTransferProviderCharm(ops.CharmBase):
+    """Class for provider charm testing."""
+
+    def __init__(self, *args):
+        """Init method for the class.
+
+        Args:
+            args: Variable list of positional arguments passed to the parent constructor.
+        """
+        super().__init__(*args)
+        self.dns_transfer = dns_transfer.DNSTransferProvides(self)
+        self.framework.observe(self.on["dns-transfer"].relation_changed, self._record_event)
+        self.framework.observe(self.on.config_changed, self._reconcile)
+
+    def _record_event(self, event: ops.EventBase) -> None:
+        """Record emitted event in the event list.
+
+        Args:
+            event: event.
+        """
+        # mypy warns us that we can import different types of events doing that.
+        # We know mypy, we know.
+        self.events.append(event)  # type: ignore # pylint: disable=no-member
+
+    def _reconcile(self, _: ops.EventBase) -> None:
+        """Reconcile charm."""
+        print("Reconcile")
+        # self.dns_transfer.update_relation_data()
+
+
+def test_requirer_get_relation_data():
+    """
+    arrange: given a requirer charm.
+    act: add the relation data.
+    assert: the relation data matches the one provided.
+    """
+    ctx = testing.Context(
+        DNSTransferRequirerCharm,
+        meta={
+            "name": "dns-transfer-secondary",
+            "provides": {"dns-transfer": {"interface": "dns-transfer"}},
+        },
+    )
+    rel = testing.Relation(
+        endpoint="dns-transfer",
+        interface="dns-transfer",
+        remote_app_name="primary",
+        remote_app_data={
+            "addresses": json.dumps(["10.10.10.10"]),
+            "zones": json.dumps(["example.com"]),
+            "transport": json.dumps("tls"),
+        },
+    )
+    state = testing.State(relations={rel})
+
+    with ctx(ctx.on.start(), state) as manager:
+        assert (
+            manager.charm.dns_transfer.get_remote_relation_data()
+            == dns_transfer.DNSTransferProviderData(
+                addresses=["10.10.10.10"],  # type: ignore[list-item]
+                transport="tls",  # type: ignore[arg-type]
+                remote_hostname=None,
+                zones=["example.com"],
+            )
+        )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR adds a new library named dns_transfer based on the spec ISD211.

For now, consider 1 primary to N secondaries.

### Rationale

Provide integration between primary and secondary DNS servers.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

New library dns_transfer.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `docs/changelog.md` file was updated

<!-- Explanation for any unchecked items above -->
No changelog for now.