### PR TITLE
Move topology handling to its own module

### DIFF
--- a/bind-operator/src/bind.py
+++ b/bind-operator/src/bind.py
@@ -22,6 +22,7 @@ import dns_data
 import exceptions
 import models
 import templates
+import topology as topology_module
 
 logger = logging.getLogger(__name__)
 
@@ -180,7 +181,7 @@ class BindService:
     def update_zonefiles_and_reload(
         self,
         relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
-        topology: models.Topology | None,
+        topology: topology_module.Topology | None,
     ) -> None:
         """Update the zonefiles from bind's config and reload bind.
 
@@ -267,7 +268,7 @@ class BindService:
             raise InstallError(error_msg) from e
 
     def _zones_to_files_content(
-        self, zones: list[models.Zone], topology: models.Topology
+        self, zones: list[models.Zone], topology: topology_module.Topology
     ) -> dict[str, str]:
         """Return zone files and their content.
 
@@ -316,7 +317,7 @@ class BindService:
         return zone_files
 
     def _generate_named_conf_local(
-        self, zones: list[str], topology: models.Topology | None
+        self, zones: list[str], topology: topology_module.Topology | None
     ) -> str:
         """Generate the content of `named.conf.local`.
 

--- a/bind-operator/src/charm.py
+++ b/bind-operator/src/charm.py
@@ -16,19 +16,10 @@ from charms.bind.v0 import dns_record
 import constants
 import dns_data
 import events
-import exceptions
-import models
+import topology
 from bind import BindService
 
 logger = logging.getLogger(__name__)
-
-
-class PeerRelationUnavailableError(exceptions.BindCharmError):
-    """Exception raised when the peer relation is unavailable."""
-
-
-class PeerRelationNetworkUnavailableError(exceptions.BindCharmError):
-    """Exception raised when the peer relation network is unavailable."""
 
 
 class BindCharm(ops.CharmBase):
@@ -43,6 +34,7 @@ class BindCharm(ops.CharmBase):
         super().__init__(*args)
         self.bind = BindService()
         self.dns_record = dns_record.DNSRecordProvides(self)
+        self.topology = topology.TopologyService(self, constants.PEER)
 
         self.on.define_event("reload_bind", events.ReloadBindEvent)
 
@@ -54,17 +46,15 @@ class BindCharm(ops.CharmBase):
         self.framework.observe(
             self.on.dns_record_relation_changed, self._on_dns_record_relation_changed
         )
+        self.framework.observe(self.topology.on.topology_changed, self._on_topology_changed)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
         self.framework.observe(self.on.reload_bind, self._on_reload_bind)
-        self.framework.observe(self.on.leader_elected, self._on_leader_elected)
-        self.framework.observe(
-            self.on[constants.PEER].relation_departed, self._on_peer_relation_departed
-        )
-        self.framework.observe(
-            self.on[constants.PEER].relation_joined, self._on_peer_relation_joined
-        )
         self.unit.open_port("tcp", 53)  # Bind DNS
         self.unit.open_port("udp", 53)  # Bind DNS
+
+    def _on_topology_changed(self, _: topology.TopologyChangedEvent) -> None:
+        """Handle topology changed events."""
+        self._reconcile()
 
     def _on_reload_bind(self, _: events.ReloadBindEvent) -> None:
         """Handle periodic reload bind event.
@@ -72,10 +62,6 @@ class BindCharm(ops.CharmBase):
         Reloading is used to take new configuration into account.
 
         """
-        self._reconcile()
-
-    def _on_peer_relation_joined(self, _: ops.RelationJoinedEvent) -> None:
-        """Handle peer relation joined event."""
         self._reconcile()
 
     def _on_dns_record_relation_changed(self, _: ops.RelationChangedEvent) -> None:
@@ -92,13 +78,13 @@ class BindCharm(ops.CharmBase):
             event: Event triggering the collect-status hook
         """
         try:
-            topology = self._topology()
-            if topology.is_current_unit_active:
+            t = self.topology.current()
+            if t.is_current_unit_active:
                 event.add_status(ops.ActiveStatus("active"))
             else:
                 event.add_status(ops.ActiveStatus())
-        except PeerRelationUnavailableError:
-            event.add_status(ops.WaitingStatus("Peer relation is not available"))
+        except topology.TopologyUnavailableError:
+            event.add_status(ops.WaitingStatus("Topology is not available"))
         relation_data = self._get_remote_relation_data()
         if relation_data is None:
             event.add_status(ops.BlockedStatus("Non valid DNS requests"))
@@ -126,44 +112,28 @@ class BindCharm(ops.CharmBase):
         self.unit.status = ops.MaintenanceStatus("Upgrading dependencies")
         self.bind.setup(self.unit.name)
 
-    def _on_leader_elected(self, _: ops.LeaderElectedEvent) -> None:
-        """Handle leader-elected event."""
-        self._reconcile()
-
-    def _on_peer_relation_departed(self, event: ops.RelationDepartedEvent) -> None:
-        """Handle the peer relation departed event.
-
-        Args:
-            event: Event triggering the relation-departed hook
-        """
-        # If we are a departing unit, we don't want to interfere with electing a new active one
-        if event.departing_unit == self.model.unit:
-            return
-
-        self._reconcile()
-
-    def _check_and_may_become_active(self, topology: models.Topology) -> bool:
+    def _check_and_may_become_active(self, t: topology.Topology) -> bool:
         """Check the active unit status and may become active if need be.
 
         Args:
-            topology: Topology of the current deployment
+            t: Topology of the current deployment
 
         Returns:
             True if the charm is effectively the new active unit.
         """
         relation = self.model.get_relation(constants.PEER)
         assert relation is not None  # nosec
-        if not topology.active_unit_ip:
-            relation.data[self.app].update({"active-unit": str(topology.current_unit_ip)})
+        if not t.active_unit_ip:
+            relation.data[self.app].update({"active-unit": str(t.current_unit_ip)})
             return True
 
         status = self._dig_query(
-            f"@{topology.active_unit_ip} service.{constants.ZONE_SERVICE_NAME} TXT +short",
+            f"@{t.active_unit_ip} service.{constants.ZONE_SERVICE_NAME} TXT +short",
             retry=True,
             wait=1,
         )
         if status != "ok":
-            relation.data[self.app].update({"active-unit": str(topology.current_unit_ip)})
+            relation.data[self.app].update({"active-unit": str(t.current_unit_ip)})
             return True
         return False
 
@@ -201,49 +171,6 @@ class BindCharm(ops.CharmBase):
 
         return result
 
-    def _topology(self) -> models.Topology:
-        """Create a network topology of the current deployment.
-
-        Returns:
-            A topology of the current deployment
-
-        Raises:
-            PeerRelationUnavailableError: when the peer relation does not exist
-            PeerRelationNetworkUnavailableError: when the network property does not exist
-        """
-        start_time = time.time_ns()
-        relation = self.model.get_relation(constants.PEER)
-        binding = self.model.get_binding(constants.PEER)
-        if not relation or not binding:
-            raise PeerRelationUnavailableError(
-                "Peer relation not available when trying to get topology."
-            )
-        if binding.network is None:
-            raise PeerRelationNetworkUnavailableError(
-                "Peer relation network not available when trying to get unit IP."
-            )
-
-        units_ip: list[str] = [
-            unit_data.get("private-address", "")
-            for _, unit_data in relation.data.items()
-            if unit_data.get("private-address", "") != ""
-        ]
-
-        current_unit_ip = str(binding.network.bind_address)
-        active_unit_ip = relation.data[self.app].get("active-unit")
-
-        logger.debug("active_unit_ip: %s", active_unit_ip)
-        logger.debug("current_unit_ip: %s", current_unit_ip)
-        logger.debug("units_ip: %s", units_ip)
-        logger.debug("topology retrieval duration (ms): %s", (time.time_ns() - start_time) / 1e6)
-
-        return models.Topology(
-            active_unit_ip=active_unit_ip,
-            units_ip=units_ip,
-            standby_units_ip=[ip for ip in units_ip if ip != active_unit_ip],
-            current_unit_ip=current_unit_ip,
-        )
-
     def _get_remote_relation_data(self) -> dns_record.DNSRecordProviderData | None:
         """Get the dns_record remote relation data.
 
@@ -263,14 +190,14 @@ class BindCharm(ops.CharmBase):
         """Reconciles."""
         # Retrieve the current topology of units
         try:
-            topology = self._topology()
-        except (PeerRelationUnavailableError, PeerRelationNetworkUnavailableError) as err:
+            t = self.topology.current()
+        except topology.TopologyUnavailableError as err:
             logger.info("Could not retrieve network topology: %s", err)
             return
 
         # If we're the leader and not active, check that the active unit is doing well
-        if self.unit.is_leader() and not topology.is_current_unit_active:
-            self._check_and_may_become_active(topology)
+        if self.unit.is_leader() and not t.is_current_unit_active:
+            self._check_and_may_become_active(t)
 
         try:
             relation_data = self.dns_record.get_remote_relation_data()
@@ -291,8 +218,8 @@ class BindCharm(ops.CharmBase):
             # If we can't load the previous state,
             # we assume that we need to regenerate the configuration
             last_valid_state = {}
-        if dns_data.has_changed(relation_data, topology, last_valid_state):
-            self.bind.update_zonefiles_and_reload(relation_data, topology)
+        if dns_data.has_changed(relation_data, t, last_valid_state):
+            self.bind.update_zonefiles_and_reload(relation_data, t)
 
         # Update dns_record relation's data if we are the leader
         if self.unit.is_leader():

--- a/bind-operator/src/charm.py
+++ b/bind-operator/src/charm.py
@@ -34,7 +34,7 @@ class BindCharm(ops.CharmBase):
         super().__init__(*args)
         self.bind = BindService()
         self.dns_record = dns_record.DNSRecordProvides(self)
-        self.topology = topology.TopologyService(self, constants.PEER)
+        self.topology = topology.TopologyObserver(self, constants.PEER)
 
         self.on.define_event("reload_bind", events.ReloadBindEvent)
 

--- a/bind-operator/src/dns_data.py
+++ b/bind-operator/src/dns_data.py
@@ -17,6 +17,7 @@ from charms.bind.v0.dns_record import (
 )
 
 import models
+import topology as topology_module
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ def create_dns_record_provider_data(
 
 def has_changed(
     relation_data: list[tuple[DNSRecordRequirerData, DNSRecordProviderData]],
-    topology: models.Topology | None,
+    topology: topology_module.Topology | None,
     last_valid_state: dict[str, typing.Any],
 ) -> bool:
     """Check if the dns data has changed.
@@ -157,7 +158,7 @@ def dns_record_relations_data_to_zones(
     return list(zones.values())
 
 
-def dump_state(zones: list[models.Zone], topology: models.Topology) -> str:
+def dump_state(zones: list[models.Zone], topology: topology_module.Topology) -> str:
     """Dump the current state.
 
     We need this cumbersome way of serializing the state because
@@ -192,6 +193,6 @@ def load_state(serialized_state: str) -> dict[str, typing.Any]:
     """
     state = json.loads(serialized_state)
     if state["topology"] is not None:
-        state["topology"] = models.Topology(**state["topology"])
+        state["topology"] = topology_module.Topology(**state["topology"])
     state["zones"] = [models.Zone(**zone) for zone in state["zones"]]
     return state

--- a/bind-operator/src/models.py
+++ b/bind-operator/src/models.py
@@ -131,29 +131,3 @@ def create_dns_entry_from_requirer_entry(requirer_entry: RequirerEntry) -> DnsEn
         record_data=requirer_entry.record_data,
         ttl=requirer_entry.ttl,
     )
-
-
-class Topology(pydantic.BaseModel):
-    """Class used to represent the current units topology.
-
-    Attributes:
-        units_ip: IPs of all the units
-        active_unit_ip: IP of the active unit
-        standby_units_ip: IPs of the standby units
-        current_unit_ip: IP of the current unit
-        is_current_unit_active: Is the current unit active ?
-    """
-
-    units_ip: list[pydantic.IPvAnyAddress]
-    active_unit_ip: pydantic.IPvAnyAddress | None
-    standby_units_ip: list[pydantic.IPvAnyAddress]
-    current_unit_ip: pydantic.IPvAnyAddress
-
-    @property
-    def is_current_unit_active(self) -> bool:
-        """Check if the current unit is the active unit.
-
-        Returns:
-            True if the current unit is effectively the active unit.
-        """
-        return self.current_unit_ip == self.active_unit_ip

--- a/bind-operator/src/topology.py
+++ b/bind-operator/src/topology.py
@@ -1,0 +1,166 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Bind charm topology logic."""
+
+import logging
+import time
+
+import ops
+import pydantic
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "bind-topology"
+
+
+class TopologyError(Exception):
+    """Base exception for the topology module."""
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the exception.
+
+        Args:
+            msg (str): Explanation of the error.
+        """
+        self.msg = msg
+
+
+class PeerRelationUnavailableError(TopologyError):
+    """Exception raised when the peer relation is unavailable."""
+
+
+class PeerRelationNetworkUnavailableError(TopologyError):
+    """Exception raised when the peer relation network is unavailable."""
+
+
+class TopologyUnavailableError(TopologyError):
+    """Exception raised when topology could not be retrieved."""
+
+
+class Topology(pydantic.BaseModel):
+    """Class used to represent the current units topology.
+
+    Attributes:
+        units_ip: IPs of all the units
+        active_unit_ip: IP of the active unit
+        standby_units_ip: IPs of the standby units
+        current_unit_ip: IP of the current unit
+        is_current_unit_active: Is the current unit active ?
+    """
+
+    units_ip: list[pydantic.IPvAnyAddress]
+    active_unit_ip: pydantic.IPvAnyAddress | None
+    standby_units_ip: list[pydantic.IPvAnyAddress]
+    current_unit_ip: pydantic.IPvAnyAddress
+
+    @property
+    def is_current_unit_active(self) -> bool:
+        """Check if the current unit is the active unit.
+
+        Returns:
+            True if the current unit is effectively the active unit.
+        """
+        return self.current_unit_ip == self.active_unit_ip
+
+
+class TopologyChangedEvent(ops.EventBase):
+    """Topology changed event."""
+
+
+class TopologyEvents(ops.CharmEvents):
+    """Topology events.
+
+    This class defines the events that a topology service can emit.
+
+    Attributes:
+        topology_changed: the topologyChangedEvent.
+    """
+
+    topology_changed = ops.EventSource(TopologyChangedEvent)
+
+
+class TopologyService(ops.Object):
+    """Topology service class.
+
+    Attrs:
+        on: custom topology events
+    """
+
+    on = TopologyEvents()
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str = DEFAULT_RELATION_NAME) -> None:
+        """Construct.
+
+        Args:
+            charm: the provider charm.
+            relation_name: the relation name.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on.leader_elected, self._on_leader_elected)
+        self.framework.observe(
+            charm.on[relation_name].relation_departed, self._on_peer_relation_departed
+        )
+        self.framework.observe(
+            charm.on[relation_name].relation_joined, self._on_peer_relation_joined
+        )
+
+    def current(self) -> Topology:
+        """Create a network topology of the current deployment.
+
+        Returns:
+            A topology of the current deployment
+
+        Raises:
+            TopologyUnavailableError: when the topology could not be created
+        """
+        start_time = time.time_ns()
+        relation = self.model.get_relation(self.relation_name)
+        binding = self.model.get_binding(self.relation_name)
+        if not relation or not binding:
+            raise TopologyUnavailableError(
+                "Peer relation not available when trying to get topology."
+            )
+        if binding.network is None:
+            raise TopologyUnavailableError(
+                "Peer relation network not available when trying to get unit IP."
+            )
+
+        units_ip: list[str] = [
+            unit_data.get("private-address", "")
+            for _, unit_data in relation.data.items()
+            if unit_data.get("private-address", "") != ""
+        ]
+
+        current_unit_ip = str(binding.network.bind_address)
+        active_unit_ip = relation.data[self.charm.app].get("active-unit")
+
+        logger.debug("active_unit_ip: %s", active_unit_ip)
+        logger.debug("current_unit_ip: %s", current_unit_ip)
+        logger.debug("units_ip: %s", units_ip)
+        logger.debug("topology retrieval duration (ms): %s", (time.time_ns() - start_time) / 1e6)
+
+        try:
+            return Topology(
+                # pydantic accepts str as IPvAnyAddress
+                active_unit_ip=active_unit_ip,  # type: ignore
+                units_ip=units_ip,  # type: ignore
+                standby_units_ip=[ip for ip in units_ip if ip != active_unit_ip],  # type: ignore
+                current_unit_ip=current_unit_ip,  # type: ignore
+            )
+        except pydantic.ValidationError as e:
+            raise TopologyUnavailableError("Error while instantiating model") from e
+
+    def _on_leader_elected(self, _: ops.LeaderElectedEvent) -> None:
+        """Handle leader-elected event."""
+        self.on.topology_changed.emit()
+
+    def _on_peer_relation_joined(self, _: ops.RelationJoinedEvent) -> None:
+        """Handle peer relation joined event."""
+        self.on.topology_changed.emit()
+
+    def _on_peer_relation_departed(self, _: ops.RelationDepartedEvent) -> None:
+        """Handle the peer relation departed event."""
+        self.on.topology_changed.emit()

--- a/bind-operator/src/topology.py
+++ b/bind-operator/src/topology.py
@@ -80,7 +80,7 @@ class TopologyEvents(ops.CharmEvents):
     topology_changed = ops.EventSource(TopologyChangedEvent)
 
 
-class TopologyService(ops.Object):
+class TopologyObserver(ops.Object):
     """Topology service class.
 
     Attrs:

--- a/bind-operator/tests/unit/conftest.py
+++ b/bind-operator/tests/unit/conftest.py
@@ -11,6 +11,7 @@ import ops
 import pytest
 import scenario
 
+import constants
 from src.charm import BindCharm
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ def context_fixture(tmp_path_factory):
 def peer_relation_fixture():
     """Peer relation fixture."""
     yield scenario.PeerRelation(
-        endpoint="bind-peers",
+        endpoint=constants.PEER,
         peers_data={},
     )
 

--- a/bind-operator/tests/unit/test_charm.py
+++ b/bind-operator/tests/unit/test_charm.py
@@ -29,7 +29,7 @@ def test_start_without_peer_relation(context, base_state):
     base_state["relations"] = []
     state = testing.State(**base_state)
     out = context.run(context.on.start(), state)
-    assert out.unit_status == testing.WaitingStatus("Peer relation is not available")
+    assert out.unit_status == testing.WaitingStatus("Topology is not available")
 
 
 @pytest.mark.usefixtures("context")

--- a/bind-operator/tests/unit/test_dns_data.py
+++ b/bind-operator/tests/unit/test_dns_data.py
@@ -8,8 +8,8 @@ import logging
 import pytest
 
 import dns_data
-import models
 import tests.unit.helpers
+import topology as topology_module
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +216,9 @@ def test_has_changed(
         [(record_requirer_data, None) for record_requirer_data in record_requirers_data_before]
     )
     topology_before = (
-        models.Topology(**topology_data_before) if topology_data_before is not None else None
+        topology_module.Topology(**topology_data_before)
+        if topology_data_before is not None
+        else None
     )
     serialized_state = dns_data.dump_state(zones, topology_before)
 
@@ -228,7 +230,11 @@ def test_has_changed(
 
     assert expected_has_changed == dns_data.has_changed(
         [(record_requirer_data, None) for record_requirer_data in record_requirers_data_after],
-        models.Topology(**topology_data_after) if topology_data_after is not None else None,
+        (
+            topology_module.Topology(**topology_data_after)
+            if topology_data_after is not None
+            else None
+        ),
         dns_data.load_state(serialized_state),
     )
 
@@ -277,7 +283,7 @@ def test_load_dump_state(integration_datasets, topology_data):
     zones = dns_data.dns_record_relations_data_to_zones(  # pylint: disable=protected-access
         [(record_requirer_data, None) for record_requirer_data in record_requirers_data]
     )
-    topology = models.Topology(**topology_data) if topology_data is not None else None
+    topology = topology_module.Topology(**topology_data) if topology_data is not None else None
 
     serialized = dns_data.dump_state(zones, topology)
     state = dns_data.load_state(serialized)


### PR DESCRIPTION
### Overview

Moving topology creation and related events to their own module to simplify the logic of `charm.py`.  
This will also make it easier to reuse it in other charms

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `docs/changelog.md` file was updated

<!-- Explanation for any unchecked items above -->
