### PR TITLE
Disable linkcheck failure

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,3 +12,4 @@ jobs:
     with:
       vale-files: './**/*.md'
       linkcheck-files: './**/*.md'
+      linkcheck-fail-on-error: false


### PR DESCRIPTION
Applicable spec: <link>

### Overview

This PR disables linkcheck on failure since is impacting PR with failures not related to the changes.

See
https://github.com/canonical/dns-operators/pull/251

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `docs/changelog.md` file was updated

<!-- Explanation for any unchecked items above -->
